### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AutoInstallerContext.initApplication(this,
 
 ````
 
-##Sample & Art
+## Sample & Art
 
 [Sample Apk, You can download from here](https://github.com/bunnybluy/ApkAutoInstaller/raw/master/art/ApkAutoInstaller.apk)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
